### PR TITLE
Edit Developer Guide's use cases for Delete Member, List All Members, List All Events

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -300,17 +300,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Extensions**
 
-* 2a. The list of all members is empty.
-
-  * 2a1. CCACommander shows an error message.
-
-    Use case ends.
-
 * 3a. The given index is invalid.
 
-    * 3a1. CCACommander shows an error message.
+    * 3a1. CCACommander shows an error message and requests for a valid index from the user.
+    * 3a2. User enters new index. 
+    * Steps 3a1-3a2 are repeated until index given by the user is correct.
 
-      Use case resumes at step 2.
+      Use case resumes at step 4.
 
 **Use case : UC02 - List all members**
 
@@ -323,14 +319,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
    Use case ends.
 
-**Extensions**
-
-* 1a. The list of all members is empty.
-
-    * 1a1. CCACommander shows an empty member list.
-
-      Use case ends.
-
 **Use case : UC03 - List all events**
 
 **Guarantees: MSS -> All events will be listed.**
@@ -341,14 +329,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 2. CCACommander lists all events in the CCA
 
    Use case ends.
-
-**Extensions**
-
-* 1a. The list of all events is empty.
-
-    * 1a1. CCACommander shows an empty event list.
-
-      Use case ends.
 
 **Use case: UC04 - View members of event**
 


### PR DESCRIPTION
* Closes #68  which was reopened to edit use cases for delete member, list all members and list all events. Changes include:
  * Edited extensions for Delete Member use case
  * Removed extensions for List All Members use case
  * Removed extensions for List All Events use case