### PR TITLE
Edit output message of undo/redo commands for Enrol specific commands

### DIFF
--- a/src/main/java/seedu/ccacommander/logic/commands/EnrolCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/EnrolCommand.java
@@ -41,7 +41,7 @@ public class EnrolCommand extends Command {
 
 
     public static final String MESSAGE_SUCCESS = "Successfully added: %1$s";
-    public static final String MESSAGE_COMMIT = "Successfully added: %1$s";
+    public static final String MESSAGE_COMMIT = "Successfully enrolled: %1$s";
     public static final String MESSAGE_DUPLICATE_ATTENDANCE = "This member has already been enrolled to the event. ";
 
     private final Index memberIndex;
@@ -91,7 +91,7 @@ public class EnrolCommand extends Command {
         }
 
         model.createAttendance(toAdd);
-        model.commit(String.format(MESSAGE_COMMIT, toAdd.toString()));
+        model.commit(String.format(MESSAGE_COMMIT, toAdd.getMemberAndEventAttendance()));
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/ccacommander/model/attendance/Attendance.java
+++ b/src/main/java/seedu/ccacommander/model/attendance/Attendance.java
@@ -48,6 +48,10 @@ public class Attendance {
         return remark;
     }
 
+    public String getMemberAndEventAttendance() {
+        return getMemberName().toString() + " to " + getEventName().toString();
+    }
+
     /**
      * Returns true if both attendance have the same identity fields.
      * This defines a weaker notion of equality between two attendance.

--- a/src/test/java/seedu/ccacommander/logic/commands/EnrolCommandIntegrationTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/EnrolCommandIntegrationTest.java
@@ -39,7 +39,8 @@ public class EnrolCommandIntegrationTest {
                 .withRemark(ALICE_AURORA.getRemark().value)
                 .build();
 
-        String commitMessage = String.format(EnrolCommand.MESSAGE_COMMIT, validAttendance.toString());
+        String commitMessage = String.format(EnrolCommand.MESSAGE_COMMIT,
+                validAttendance.getMemberAndEventAttendance());
         Model expectedModel = new ModelManager(model.getCcaCommander(), new UserPrefs());
         expectedModel.createAttendance(validAttendance);
         expectedModel.commit(commitMessage);


### PR DESCRIPTION
The current behaviour of undo/redo command for Enrol specific command is wrong as it outputs a cryptic looking message upon undoing/redoing the Enrol command. This is due to `EnrolCommand` class using the `toString()` method of the `Attendance` class to output the message.

A new method is created for `Attendance` class, which is called `getMemberAndEventAttendance()`. This method formats the output message to be more user-friendly and less cryptic. The `EnrolCommand` then calls on this method to display the more user-friendly message.

Doing so will make the output message clearer and does not expose the internal structure of the code to the user.