### PR TITLE
Add Command History

### DIFF
--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -30,7 +30,7 @@ public class CommandHistory {
         requireNonNull(command);
         String trimmedCommand = command.trim();
         if (trimmedCommand.length() == 0) {
-           return;
+            return;
         }
 
         if (this.commandHistoryList.size() == 0

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The facilitator of commands and functions related to recalling previously entered commands.
+ * The facilitator of storing commands and functions related to recalling previously entered commands.
  */
 public class CommandHistory {
     private List<String> commandHistoryList;
@@ -35,12 +35,18 @@ public class CommandHistory {
         }
     }
 
+    /**
+     * Returns true if last command in {@code commandHistoryList} is equal to param command.
+     *
+     * @param command
+     */
     public boolean isLastCommandEqualCommand(String command) {
         return this.commandHistoryList.get(this.commandHistoryList.size() - 1).equals(command);
     }
 
     /**
-     * @return true if there is a next command.
+     * Returns true if there is a next command.
+     * @return boolean value of whether a next command exists.
      */
     public boolean hasNextCommand() {
         boolean hasCommands = this.commandHistoryList.size() > 0;
@@ -50,7 +56,7 @@ public class CommandHistory {
     }
 
     /**
-     * @return true if there is a previous command.
+     * Returns true if there is a previous command.
      */
     public boolean hasPreviousCommand() {
         boolean hasCommands = this.commandHistoryList.size() > 0;
@@ -59,7 +65,8 @@ public class CommandHistory {
     }
 
     /**
-     * @return next command in the {@code commandHistoryList} based on the {@code currentCommandPointer}
+     * Returns next command.
+     * Must be used in conjunction with {@code hasNextCommand} hence the assertion.
      */
     public String getNextCommand() {
         assert this.currentCommandPointer < this.commandHistoryList.size() - 1
@@ -70,7 +77,8 @@ public class CommandHistory {
     }
 
     /**
-     * @return previous command in the {@code commandHistoryList} based on the {@code currentCommandPointer}
+     * Returns previous command.
+     * Must be used in conjunction with {@code hasPreviousCommand} hence the assertion.
      */
     public String getPreviousCommand() {
         assert this.currentCommandPointer > 0
@@ -89,7 +97,7 @@ public class CommandHistory {
     }
 
     /**
-     * @return true if the pointer is at the last command.
+     * Returns true if the pointer is at the last command.
      */
     public boolean isLastCommand() {
         return this.currentCommandPointer == this.commandHistoryList.size() - 1;

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -28,9 +28,14 @@ public class CommandHistory {
      */
     public void addCommand(String command) {
         requireNonNull(command);
+        String trimmedCommand = command.trim();
+        if (trimmedCommand.length() == 0) {
+           return;
+        }
+
         if (this.commandHistoryList.size() == 0
-                || !isLastCommandEqualCommand(command)) {
-            this.commandHistoryList.add(command);
+                || !isLastCommandEqualCommand(trimmedCommand)) {
+            this.commandHistoryList.add(trimmedCommand);
             resetPointer();
         }
     }

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -62,6 +62,8 @@ public class CommandHistory {
      * @return next command in the {@code commandHistoryList} based on the {@code currentCommandPointer}
      */
     public String getNextCommand() {
+        assert this.currentCommandPointer < this.commandHistoryList.size() - 1
+                : "currentCommandPointer is at the newest command already";
         this.currentCommandPointer++;
         String nextCommand = this.commandHistoryList.get(this.currentCommandPointer);
         return nextCommand;
@@ -71,6 +73,8 @@ public class CommandHistory {
      * @return previous command in the {@code commandHistoryList} based on the {@code currentCommandPointer}
      */
     public String getPreviousCommand() {
+        assert this.currentCommandPointer > 0
+                : "currentCommandPointer is at the last command already";
         this.currentCommandPointer--;
         String command = this.commandHistoryList.get(this.currentCommandPointer);
         return command;

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -74,7 +74,7 @@ public class CommandHistory {
      */
     public String getPreviousCommand() {
         assert this.currentCommandPointer > 0
-                : "currentCommandPointer is at the last command already";
+                : "currentCommandPointer is at the oldest command already";
         this.currentCommandPointer--;
         String command = this.commandHistoryList.get(this.currentCommandPointer);
         return command;

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -29,10 +29,14 @@ public class CommandHistory {
     public void addCommand(String command) {
         requireNonNull(command);
         if (this.commandHistoryList.size() == 0
-                || !this.commandHistoryList.get(this.commandHistoryList.size() - 1).equals(command)) {
+                || !isLastCommandEqualCommand(command)) {
             this.commandHistoryList.add(command);
             resetPointer();
         }
+    }
+
+    public boolean isLastCommandEqualCommand(String command) {
+        return this.commandHistoryList.get(this.commandHistoryList.size() - 1).equals(command);
     }
 
     /**

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -1,0 +1,75 @@
+package seedu.ccacommander.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CommandHistory {
+    private List<String> commandHistoryList;
+    private int currentCommandPointer;
+
+    /**
+     * Constructs a new instance of CommandHistory.
+     */
+    public CommandHistory() {
+        this.commandHistoryList = new ArrayList<>();
+        this.currentCommandPointer = 0;
+    }
+
+    /**
+     * Adds the command into {@code commandHistoryList} and sets the pointer to the new command only if the command
+     * is not the latest command added.
+     *
+     * @param command
+     */
+    public void addCommand(String command) {
+        requireNonNull(command);
+        if (this.commandHistoryList.size() == 0 ||
+                this.commandHistoryList.get(this.commandHistoryList.size() - 1) != command) {
+            this.commandHistoryList.add(command);
+            this.currentCommandPointer = this.commandHistoryList.size();
+        }
+    }
+
+    /**
+     * @return if there is a next command.
+     */
+    public boolean hasNextCommand() {
+        boolean hasCommands = this.commandHistoryList.size() > 0;
+        boolean pointerHasNext = this.currentCommandPointer < this.commandHistoryList.size() - 1;
+        return pointerHasNext && hasCommands;
+
+    }
+    /**
+     * @return if there is a previous command.
+     */
+    public boolean hasPreviousCommand() {
+        boolean hasCommands = this.commandHistoryList.size() > 0;
+        boolean pointerHasPrevious = this.currentCommandPointer > 0;
+        return pointerHasPrevious && hasCommands;
+    }
+
+    /**
+     * @return next command in the {@code commandHistoryList} based on the {@code currentCommandPointer}
+     */
+    public String getNextCommand() {
+        if (hasNextCommand()) {
+            this.currentCommandPointer++;
+            return this.commandHistoryList.get(currentCommandPointer);
+        }
+        return null;
+    }
+
+    /**
+     * @return previous command in the {@code commandHistoryList} based on the {@code currentCommandPointer}
+     */
+    public String getPreviousCommand() {
+        if (hasPreviousCommand()) {
+            this.currentCommandPointer--;
+            return this.commandHistoryList.get(currentCommandPointer);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -5,6 +5,9 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * The facilitator of commands and functions related to recalling previously entered commands.
+ */
 public class CommandHistory {
     private List<String> commandHistoryList;
     private int currentCommandPointer;
@@ -25,8 +28,8 @@ public class CommandHistory {
      */
     public void addCommand(String command) {
         requireNonNull(command);
-        if (this.commandHistoryList.size() == 0 ||
-                !this.commandHistoryList.get(this.commandHistoryList.size() - 1).equals(command)) {
+        if (this.commandHistoryList.size() == 0
+                || !this.commandHistoryList.get(this.commandHistoryList.size() - 1).equals(command)) {
             this.commandHistoryList.add(command);
             resetPointer();
         }

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -26,14 +26,14 @@ public class CommandHistory {
     public void addCommand(String command) {
         requireNonNull(command);
         if (this.commandHistoryList.size() == 0 ||
-                this.commandHistoryList.get(this.commandHistoryList.size() - 1) != command) {
+                !this.commandHistoryList.get(this.commandHistoryList.size() - 1).equals(command)) {
             this.commandHistoryList.add(command);
-            this.currentCommandPointer = this.commandHistoryList.size();
+            resetPointer();
         }
     }
 
     /**
-     * @return if there is a next command.
+     * @return true if there is a next command.
      */
     public boolean hasNextCommand() {
         boolean hasCommands = this.commandHistoryList.size() > 0;
@@ -41,8 +41,9 @@ public class CommandHistory {
         return pointerHasNext && hasCommands;
 
     }
+
     /**
-     * @return if there is a previous command.
+     * @return true if there is a previous command.
      */
     public boolean hasPreviousCommand() {
         boolean hasCommands = this.commandHistoryList.size() > 0;
@@ -54,22 +55,33 @@ public class CommandHistory {
      * @return next command in the {@code commandHistoryList} based on the {@code currentCommandPointer}
      */
     public String getNextCommand() {
-        if (hasNextCommand()) {
-            this.currentCommandPointer++;
-            return this.commandHistoryList.get(currentCommandPointer);
-        }
-        return null;
+        this.currentCommandPointer++;
+        String nextCommand = this.commandHistoryList.get(this.currentCommandPointer);
+        return nextCommand;
     }
 
     /**
      * @return previous command in the {@code commandHistoryList} based on the {@code currentCommandPointer}
      */
     public String getPreviousCommand() {
-        if (hasPreviousCommand()) {
-            this.currentCommandPointer--;
-            return this.commandHistoryList.get(currentCommandPointer);
-        }
-        return null;
+        this.currentCommandPointer--;
+        String command = this.commandHistoryList.get(this.currentCommandPointer);
+        return command;
+    }
+
+    /**
+     * Resets the pointer to after the last command (no next command available, only previous commands available)
+     * This will be used to move the pointer past the last command.
+     */
+    public void resetPointer() {
+        this.currentCommandPointer = this.commandHistoryList.size();
+    }
+
+    /**
+     * @return true if the pointer is at the last command.
+     */
+    public boolean isLastCommand() {
+        return this.currentCommandPointer == this.commandHistoryList.size() - 1;
     }
 
 }

--- a/src/main/java/seedu/ccacommander/ui/CommandBox.java
+++ b/src/main/java/seedu/ccacommander/ui/CommandBox.java
@@ -50,6 +50,7 @@ public class CommandBox extends UiPart<Region> {
                 }
                 break;
             case BACK_SPACE:
+            case ENTER:
                 COMMAND_HISTORY.resetPointer();
                 break;
             default:

--- a/src/main/java/seedu/ccacommander/ui/CommandBox.java
+++ b/src/main/java/seedu/ccacommander/ui/CommandBox.java
@@ -7,6 +7,7 @@ import javafx.scene.layout.Region;
 import seedu.ccacommander.logic.commands.CommandResult;
 import seedu.ccacommander.logic.commands.exceptions.CommandException;
 import seedu.ccacommander.logic.parser.exceptions.ParseException;
+import seedu.ccacommander.model.CommandHistory;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -15,7 +16,7 @@ public class CommandBox extends UiPart<Region> {
 
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
-
+    private static final CommandHistory COMMAND_HISTORY = new CommandHistory();
     private final CommandExecutor commandExecutor;
 
     @FXML
@@ -29,6 +30,30 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.setOnKeyPressed(event -> {
+            switch (event.getCode()) {
+            case UP:
+                if(COMMAND_HISTORY.hasPreviousCommand()) {
+                    String previousCommand = COMMAND_HISTORY.getPreviousCommand();
+                    commandTextField.setText(previousCommand);
+                    commandTextField.positionCaret(previousCommand.length());
+                }
+                break;
+            case DOWN:
+                if(COMMAND_HISTORY.hasNextCommand()) {
+                    String nextCommand = COMMAND_HISTORY.getNextCommand();
+                    commandTextField.setText(nextCommand);
+                    commandTextField.positionCaret(nextCommand.length());
+                } else if(COMMAND_HISTORY.isLastCommand()) {
+                    COMMAND_HISTORY.resetPointer();
+                    commandTextField.setText("");
+                }
+                break;
+            case BACK_SPACE:
+                COMMAND_HISTORY.resetPointer();
+                break;
+            }
+        });
     }
 
     /**
@@ -42,6 +67,7 @@ public class CommandBox extends UiPart<Region> {
         }
 
         try {
+            COMMAND_HISTORY.addCommand(commandText);
             commandExecutor.execute(commandText);
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/ccacommander/ui/CommandBox.java
+++ b/src/main/java/seedu/ccacommander/ui/CommandBox.java
@@ -33,24 +33,26 @@ public class CommandBox extends UiPart<Region> {
         commandTextField.setOnKeyPressed(event -> {
             switch (event.getCode()) {
             case UP:
-                if(COMMAND_HISTORY.hasPreviousCommand()) {
+                if (COMMAND_HISTORY.hasPreviousCommand()) {
                     String previousCommand = COMMAND_HISTORY.getPreviousCommand();
                     commandTextField.setText(previousCommand);
                     commandTextField.positionCaret(previousCommand.length());
                 }
                 break;
             case DOWN:
-                if(COMMAND_HISTORY.hasNextCommand()) {
+                if (COMMAND_HISTORY.hasNextCommand()) {
                     String nextCommand = COMMAND_HISTORY.getNextCommand();
                     commandTextField.setText(nextCommand);
                     commandTextField.positionCaret(nextCommand.length());
-                } else if(COMMAND_HISTORY.isLastCommand()) {
+                } else if (COMMAND_HISTORY.isLastCommand()) {
                     COMMAND_HISTORY.resetPointer();
                     commandTextField.setText("");
                 }
                 break;
             case BACK_SPACE:
                 COMMAND_HISTORY.resetPointer();
+                break;
+            default:
                 break;
             }
         });

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 public class CommandHistoryTest {
     public static final String FIRST_COMMAND = "FIRST COMMAND";
     public static final String SECOND_COMMAND = "SECOND COMMAND";
+    public static final String COMMAND_WITH_WHITESPACE = "    COMMAND WITH LEADING AND TRAILING WHITESPACE    ";
+    public static final String COMMAND_WITHOUT_WHITESPACE = "COMMAND WITH LEADING AND TRAILING WHITESPACE";
 
     private CommandHistory commandHistory;
 
@@ -30,6 +32,15 @@ public class CommandHistoryTest {
     @Test
     public void addCommand_nullCommand_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> commandHistory.addCommand(null));
+    }
+
+    @Test
+    public void addCommand_AddsTrimmedCommands() {
+        commandHistory.addCommand(COMMAND_WITH_WHITESPACE);
+        commandHistory.addCommand("     ");
+        String previousCommand = commandHistory.getPreviousCommand();
+
+        assertTrue(previousCommand.equals(COMMAND_WITHOUT_WHITESPACE));
     }
 
     @Test

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -41,6 +41,19 @@ public class CommandHistoryTest {
     }
 
     @Test
+    public void isLastCommandEqualsCommand_oneCommandAdded_returnsTrue() {
+        commandHistory.addCommand(FIRST_COMMAND);
+        assertTrue(commandHistory.isLastCommandEqualCommand(FIRST_COMMAND));
+    }
+
+
+    @Test
+    public void isLastCommandEqualsCommand_oneCommandAdded_returnsFalse() {
+        commandHistory.addCommand(FIRST_COMMAND);
+        assertFalse(commandHistory.isLastCommandEqualCommand(SECOND_COMMAND));
+    }
+
+    @Test
     public void hasNextCommand_noCommandsAdded_returnsFalse() {
         assertFalse(commandHistory.hasNextCommand());
     }

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -89,12 +89,22 @@ public class CommandHistoryTest {
         assertEquals(SECOND_COMMAND, nextCommand);
     }
 
+    @Test
+    public void getNextCommand_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> commandHistory.getNextCommand());
+    }
+
 
     @Test
     public void getPreviousCommand_hasPreviousCommand_returnsPreviousCommand() {
         commandHistory.addCommand(FIRST_COMMAND);
         String previousCommand = commandHistory.getPreviousCommand();
         assertEquals(FIRST_COMMAND, previousCommand);
+    }
+
+    @Test
+    public void getPreviousCommand_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> commandHistory.getPreviousCommand());
     }
 
     @Test

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -2,8 +2,8 @@ package seedu.ccacommander.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.ccacommander.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,7 +91,8 @@ public class CommandHistoryTest {
 
     @Test
     public void getNextCommand_throwsAssertionError() {
-        assertThrows(AssertionError.class, () -> commandHistory.getNextCommand());
+        AssertionError thrown = assertThrows(AssertionError.class, () -> commandHistory.getNextCommand());
+        assertTrue(thrown.getMessage().equals("currentCommandPointer is at the newest command already"));
     }
 
 
@@ -104,7 +105,8 @@ public class CommandHistoryTest {
 
     @Test
     public void getPreviousCommand_throwsAssertionError() {
-        assertThrows(AssertionError.class, () -> commandHistory.getPreviousCommand());
+        AssertionError thrown = assertThrows(AssertionError.class, () -> commandHistory.getPreviousCommand());
+        assertTrue(thrown.getMessage().equals("currentCommandPointer is at the oldest command already"));
     }
 
     @Test

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -35,7 +35,7 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void addCommand_AddsTrimmedCommands() {
+    public void addCommand_onlyAddsTrimmedCommands() {
         commandHistory.addCommand(COMMAND_WITH_WHITESPACE);
         commandHistory.addCommand("     ");
         String previousCommand = commandHistory.getPreviousCommand();

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -37,18 +37,19 @@ public class CommandHistoryTest {
         commandHistory.addCommand(FIRST_COMMAND);
         commandHistory.addCommand(FIRST_COMMAND);
         commandHistory.getPreviousCommand();
+
         assertFalse(commandHistory.hasPreviousCommand());
     }
 
     @Test
-    public void isLastCommandEqualsCommand_oneCommandAdded_returnsTrue() {
+    public void isLastCommandEqualCommand_oneCommandAdded_returnsTrue() {
         commandHistory.addCommand(FIRST_COMMAND);
         assertTrue(commandHistory.isLastCommandEqualCommand(FIRST_COMMAND));
     }
 
 
     @Test
-    public void isLastCommandEqualsCommand_oneCommandAdded_returnsFalse() {
+    public void isLastCommandEqualCommand_oneCommandAdded_returnsFalse() {
         commandHistory.addCommand(FIRST_COMMAND);
         assertFalse(commandHistory.isLastCommandEqualCommand(SECOND_COMMAND));
     }
@@ -64,6 +65,7 @@ public class CommandHistoryTest {
         commandHistory.addCommand(SECOND_COMMAND);
         commandHistory.getPreviousCommand();
         commandHistory.getPreviousCommand();
+
         assertTrue(commandHistory.hasNextCommand());
     }
 
@@ -82,9 +84,9 @@ public class CommandHistoryTest {
     public void getNextCommand_hasNextCommand_returnsNextCommand() {
         commandHistory.addCommand(FIRST_COMMAND);
         commandHistory.addCommand(SECOND_COMMAND);
+        commandHistory.getPreviousCommand();
+        commandHistory.getPreviousCommand();
 
-        commandHistory.getPreviousCommand();
-        commandHistory.getPreviousCommand();
         String nextCommand = commandHistory.getNextCommand();
         assertEquals(SECOND_COMMAND, nextCommand);
     }
@@ -99,6 +101,7 @@ public class CommandHistoryTest {
     @Test
     public void getPreviousCommand_hasPreviousCommand_returnsPreviousCommand() {
         commandHistory.addCommand(FIRST_COMMAND);
+
         String previousCommand = commandHistory.getPreviousCommand();
         assertEquals(FIRST_COMMAND, previousCommand);
     }
@@ -113,6 +116,7 @@ public class CommandHistoryTest {
     public void isLastCommand_returnsTrue() {
         commandHistory.addCommand(FIRST_COMMAND);
         commandHistory.getPreviousCommand();
+
         assertTrue(commandHistory.isLastCommand());
     }
 

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -33,6 +33,14 @@ public class CommandHistoryTest {
     }
 
     @Test
+    public void addCommand_doesNotAddDuplicateCommand() {
+        commandHistory.addCommand(FIRST_COMMAND);
+        commandHistory.addCommand(FIRST_COMMAND);
+        commandHistory.getPreviousCommand();
+        assertFalse(commandHistory.hasPreviousCommand());
+    }
+
+    @Test
     public void hasNextCommand_noCommandsAdded_returnsFalse() {
         assertFalse(commandHistory.hasNextCommand());
     }
@@ -74,6 +82,13 @@ public class CommandHistoryTest {
         commandHistory.addCommand(FIRST_COMMAND);
         String previousCommand = commandHistory.getPreviousCommand();
         assertEquals(FIRST_COMMAND, previousCommand);
+    }
+
+    @Test
+    public void isLastCommand_returnsTrue() {
+        commandHistory.addCommand(FIRST_COMMAND);
+        commandHistory.getPreviousCommand();
+        assertTrue(commandHistory.isLastCommand());
     }
 
 }

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -1,0 +1,81 @@
+package seedu.ccacommander.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.ccacommander.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+public class CommandHistoryTest {
+    private CommandHistory commandHistory;
+
+    public static final String FIRST_COMMAND = "FIRST COMMAND";
+    public static final String SECOND_COMMAND = "SECOND COMMAND";
+
+    @BeforeEach
+    public void setUp() {
+        commandHistory = new CommandHistory();
+    }
+
+    @Test
+    public void addCommand_nullCommand_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> commandHistory.addCommand(null));
+    }
+
+    @Test
+    public void hasNextCommand_noCommandsAdded_returnsFalse() {
+        assertFalse(commandHistory.hasNextCommand());
+    }
+
+    @Test
+    public void hasNextCommand_hasCommandsAdded_returnsTrue() {
+        commandHistory.addCommand(FIRST_COMMAND);
+        commandHistory.addCommand(SECOND_COMMAND);
+        commandHistory.getPreviousCommand();
+        commandHistory.getPreviousCommand();
+        assertTrue(commandHistory.hasNextCommand());
+    }
+
+    @Test
+    public void hasPreviousCommand_noCommandsAdded_returnsFalse() {
+        assertFalse(commandHistory.hasPreviousCommand());
+    }
+
+    @Test
+    public void hasPreviousCommand_hasCommandsAdded_returnsTrue() {
+        commandHistory.addCommand(FIRST_COMMAND);
+        assertTrue(commandHistory.hasPreviousCommand());
+    }
+
+    @Test
+    public void getNextCommand_hasNextCommand_returnsNextCommand() {
+        commandHistory.addCommand(FIRST_COMMAND);
+        commandHistory.addCommand(SECOND_COMMAND);
+
+        commandHistory.getPreviousCommand();
+        commandHistory.getPreviousCommand();
+        String nextCommand = commandHistory.getNextCommand();
+        assertEquals(SECOND_COMMAND, nextCommand);
+    }
+
+    @Test
+    public void getNextCommand_noNextCommand_returnsNull() {
+        assertNull(commandHistory.getNextCommand());
+    }
+
+    @Test
+    public void getPreviousCommand_hasPreviousCommand_returnsPreviousCommand() {
+        commandHistory.addCommand(FIRST_COMMAND);
+        String previousCommand = commandHistory.getPreviousCommand();
+        assertEquals(FIRST_COMMAND, previousCommand);
+    }
+
+    @Test
+    public void getPreviousCommand_noPreviousCommand_returnsNull() {
+        assertNull(commandHistory.getPreviousCommand());
+    }
+}

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -2,7 +2,6 @@ package seedu.ccacommander.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.ccacommander.testutil.Assert.assertThrows;
 
@@ -11,10 +10,10 @@ import org.junit.jupiter.api.Test;
 
 
 public class CommandHistoryTest {
-    private CommandHistory commandHistory;
-
     public static final String FIRST_COMMAND = "FIRST COMMAND";
     public static final String SECOND_COMMAND = "SECOND COMMAND";
+
+    private CommandHistory commandHistory;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/ccacommander/model/CommandHistoryTest.java
@@ -22,6 +22,13 @@ public class CommandHistoryTest {
     }
 
     @Test
+    public void constructor_hasNoCommands() {
+        assertFalse(commandHistory.hasNextCommand());
+        assertFalse(commandHistory.hasPreviousCommand());
+        assertFalse(commandHistory.isLastCommand());
+    }
+
+    @Test
     public void addCommand_nullCommand_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> commandHistory.addCommand(null));
     }
@@ -62,10 +69,6 @@ public class CommandHistoryTest {
         assertEquals(SECOND_COMMAND, nextCommand);
     }
 
-    @Test
-    public void getNextCommand_noNextCommand_returnsNull() {
-        assertNull(commandHistory.getNextCommand());
-    }
 
     @Test
     public void getPreviousCommand_hasPreviousCommand_returnsPreviousCommand() {
@@ -74,8 +77,4 @@ public class CommandHistoryTest {
         assertEquals(FIRST_COMMAND, previousCommand);
     }
 
-    @Test
-    public void getPreviousCommand_noPreviousCommand_returnsNull() {
-        assertNull(commandHistory.getPreviousCommand());
-    }
 }


### PR DESCRIPTION
Closes #139 

**What have you done in this PR?**
* Added CommandHistory class to store commands
  * Contains a `commandHistoryList` and `currentCommandPointer` to see which command is next or before
  * `hasNextCommand()` / `hasPreviousCommand()` to check whether there is a next/previous command
  * `getNextCommand()` / `getPreviousCommand()` to get the next/previous command
  * `resetPointer()` to reset pointer to past the last command so there are only previous commands left
  * `isLastCommand()` to get whether pointer is at the last command
  * `addCommand()` to add a command into `commandHistoryList` 
* CaseSwitch Statements based on KeyPressed in CommandBox to trigger CommandHistory functions
  * Up arrow for previous command
  * Down arrow for next command
  * BackSpace to reset pointer

**Dev Testing Steps / Screenshots**
* Type a few commands (including wrong commands)
* Select the commandBox and press up arrow and down arrow
* When selecting a previous command and deleting it, it will reset the pointer, only allowing it to navigate back again
* Wrong commands currently will be saved 

**Specification TL;DR**
UpArrow -> Recall back
DownArrow -> Recall next until blank
BackSpace -> Reset pointer, in case of users deleting with the pointer halfway through the list and making it stuck. We can remove this feature too.

You can read the full commit messages for more information too.

**Feedback required:**
* Currently wrong commands will be saved in the history too, should we only store successful commands, I am currently following the standards in my terminal where they store wrong commands too.