### PR TITLE
Fix delete commands to delete associated enrolment

### DIFF
--- a/src/main/java/seedu/ccacommander/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/DeleteEventCommand.java
@@ -2,6 +2,7 @@ package seedu.ccacommander.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.ccacommander.commons.core.index.Index;
@@ -9,7 +10,9 @@ import seedu.ccacommander.commons.util.ToStringBuilder;
 import seedu.ccacommander.logic.Messages;
 import seedu.ccacommander.logic.commands.exceptions.CommandException;
 import seedu.ccacommander.model.Model;
+import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.event.Event;
+import seedu.ccacommander.model.shared.Name;
 
 /**
  * Deletes an event identified using its displayed index from CcaCommander.
@@ -33,12 +36,28 @@ public class DeleteEventCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Event> lastShownList = model.getFilteredEventList();
+        List<Enrolment> enrolmentsList = model.getFilteredEnrolmentList();
+        List<Enrolment> enrolmentsToBeDeletedList = new ArrayList<>();
+
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
         }
 
         Event eventToDelete = lastShownList.get(targetIndex.getZeroBased());
+        Name eventToDeleteName = eventToDelete.getName();
+
+
+        for (Enrolment enrolment: enrolmentsList) {
+            if (enrolment.getEventName().equals(eventToDeleteName)) {
+                enrolmentsToBeDeletedList.add(enrolment);
+            }
+        }
+
+        for (Enrolment enrolment: enrolmentsToBeDeletedList) {
+            model.deleteEnrolment(enrolment);
+        }
+
         model.deleteEvent(eventToDelete);
         model.commit(String.format(MESSAGE_COMMIT, eventToDelete.getName()));
         return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, Messages.format(eventToDelete)));

--- a/src/main/java/seedu/ccacommander/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/DeleteEventCommand.java
@@ -2,7 +2,6 @@ package seedu.ccacommander.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import seedu.ccacommander.commons.core.index.Index;
@@ -10,7 +9,6 @@ import seedu.ccacommander.commons.util.ToStringBuilder;
 import seedu.ccacommander.logic.Messages;
 import seedu.ccacommander.logic.commands.exceptions.CommandException;
 import seedu.ccacommander.model.Model;
-import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.event.Event;
 import seedu.ccacommander.model.shared.Name;
 
@@ -36,8 +34,6 @@ public class DeleteEventCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Event> lastShownList = model.getFilteredEventList();
-        List<Enrolment> enrolmentsList = model.getFilteredEnrolmentList();
-        List<Enrolment> enrolmentsToBeDeletedList = new ArrayList<>();
 
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
@@ -47,18 +43,8 @@ public class DeleteEventCommand extends Command {
         Event eventToDelete = lastShownList.get(targetIndex.getZeroBased());
         Name eventToDeleteName = eventToDelete.getName();
 
-
-        for (Enrolment enrolment: enrolmentsList) {
-            if (enrolment.getEventName().equals(eventToDeleteName)) {
-                enrolmentsToBeDeletedList.add(enrolment);
-            }
-        }
-
-        for (Enrolment enrolment: enrolmentsToBeDeletedList) {
-            model.deleteEnrolment(enrolment);
-        }
-
         model.deleteEvent(eventToDelete);
+        model.deleteEnrolmentsWithEventName(eventToDeleteName);
         model.commit(String.format(MESSAGE_COMMIT, eventToDelete.getName()));
         return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, Messages.format(eventToDelete)));
     }

--- a/src/main/java/seedu/ccacommander/logic/commands/DeleteMemberCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/DeleteMemberCommand.java
@@ -36,8 +36,6 @@ public class DeleteMemberCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Member> lastShownList = model.getFilteredMemberList();
-        List<Enrolment> enrolmentsList = model.getFilteredEnrolmentList();
-        List<Enrolment> enrolmentsToBeDeletedList = new ArrayList<>();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_MEMBER_DISPLAYED_INDEX);

--- a/src/main/java/seedu/ccacommander/logic/commands/DeleteMemberCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/DeleteMemberCommand.java
@@ -2,6 +2,7 @@ package seedu.ccacommander.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.ccacommander.commons.core.index.Index;
@@ -9,7 +10,9 @@ import seedu.ccacommander.commons.util.ToStringBuilder;
 import seedu.ccacommander.logic.Messages;
 import seedu.ccacommander.logic.commands.exceptions.CommandException;
 import seedu.ccacommander.model.Model;
+import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.member.Member;
+import seedu.ccacommander.model.shared.Name;
 
 /**
  * Deletes a member identified using its displayed index from CcaCommander.
@@ -33,12 +36,26 @@ public class DeleteMemberCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Member> lastShownList = model.getFilteredMemberList();
+        List<Enrolment> enrolmentsList = model.getFilteredEnrolmentList();
+        List<Enrolment> enrolmentsToBeDeletedList = new ArrayList<>();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_MEMBER_DISPLAYED_INDEX);
         }
 
         Member memberToDelete = lastShownList.get(targetIndex.getZeroBased());
+        Name memberToDeleteName = memberToDelete.getName();
+
+        for (Enrolment enrolment: enrolmentsList) {
+            if (enrolment.getMemberName().equals(memberToDeleteName)) {
+                enrolmentsToBeDeletedList.add(enrolment);
+            }
+        }
+
+        for (Enrolment enrolment: enrolmentsToBeDeletedList) {
+            model.deleteEnrolment(enrolment);
+        }
+
         model.deleteMember(memberToDelete);
         model.commit(String.format(MESSAGE_COMMIT, memberToDelete.getName()));
         return new CommandResult(String.format(MESSAGE_DELETE_MEMBER_SUCCESS, Messages.format(memberToDelete)));

--- a/src/main/java/seedu/ccacommander/logic/commands/DeleteMemberCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/DeleteMemberCommand.java
@@ -2,7 +2,6 @@ package seedu.ccacommander.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import seedu.ccacommander.commons.core.index.Index;
@@ -10,7 +9,6 @@ import seedu.ccacommander.commons.util.ToStringBuilder;
 import seedu.ccacommander.logic.Messages;
 import seedu.ccacommander.logic.commands.exceptions.CommandException;
 import seedu.ccacommander.model.Model;
-import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.member.Member;
 import seedu.ccacommander.model.shared.Name;
 

--- a/src/main/java/seedu/ccacommander/logic/commands/DeleteMemberCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/DeleteMemberCommand.java
@@ -46,17 +46,8 @@ public class DeleteMemberCommand extends Command {
         Member memberToDelete = lastShownList.get(targetIndex.getZeroBased());
         Name memberToDeleteName = memberToDelete.getName();
 
-        for (Enrolment enrolment: enrolmentsList) {
-            if (enrolment.getMemberName().equals(memberToDeleteName)) {
-                enrolmentsToBeDeletedList.add(enrolment);
-            }
-        }
-
-        for (Enrolment enrolment: enrolmentsToBeDeletedList) {
-            model.deleteEnrolment(enrolment);
-        }
-
         model.deleteMember(memberToDelete);
+        model.deleteEnrolmentsWithMemberName(memberToDeleteName);
         model.commit(String.format(MESSAGE_COMMIT, memberToDelete.getName()));
         return new CommandResult(String.format(MESSAGE_DELETE_MEMBER_SUCCESS, Messages.format(memberToDelete)));
     }

--- a/src/main/java/seedu/ccacommander/model/Model.java
+++ b/src/main/java/seedu/ccacommander/model/Model.java
@@ -8,6 +8,7 @@ import seedu.ccacommander.commons.core.GuiSettings;
 import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.event.Event;
 import seedu.ccacommander.model.member.Member;
+import seedu.ccacommander.model.shared.Name;
 
 /**
  * The API of the Model component.
@@ -114,6 +115,16 @@ public interface Model {
      * The enrolment must exist in CcaCommander.
      */
     void deleteEnrolment(Enrolment target);
+
+    /**
+     * Deletes all enrolments with matching eventName.
+     */
+    void deleteEnrolmentsWithEventName(Name eventName);
+
+    /**
+     * Deletes all enrolments with matching memberName
+     */
+    void deleteEnrolmentsWithMemberName(Name memberName);
 
     /**
      * Creates the given event.

--- a/src/main/java/seedu/ccacommander/model/ModelManager.java
+++ b/src/main/java/seedu/ccacommander/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.ccacommander.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -152,6 +153,35 @@ public class ModelManager implements Model {
         versionedCcaCommander.removeEnrolment(target);
     }
 
+    @Override
+    public void deleteEnrolmentsWithEventName(Name eventName) {
+        List<Enrolment> enrolmentsToBeDeletedList = new ArrayList<>();
+        for (Enrolment enrolment: this.filteredEnrolments) {
+            if (enrolment.getEventName().equals(eventName)) {
+                // The enrolments cannot directly be deleted as it will affect the iteration of enrolments here.
+                enrolmentsToBeDeletedList.add(enrolment);
+            }
+        }
+
+        for (Enrolment enrolment: enrolmentsToBeDeletedList) {
+            this.deleteEnrolment(enrolment);
+        }
+    }
+
+    @Override
+    public void deleteEnrolmentsWithMemberName(Name memberName) {
+        List<Enrolment> enrolmentsToBeDeletedList = new ArrayList<>();
+        for (Enrolment enrolment: this.filteredEnrolments) {
+            if (enrolment.getMemberName().equals(memberName)) {
+                // The enrolments cannot directly be deleted as it will affect the iteration of enrolments here.
+                enrolmentsToBeDeletedList.add(enrolment);
+            }
+        }
+
+        for (Enrolment enrolment: enrolmentsToBeDeletedList) {
+            this.deleteEnrolment(enrolment);
+        }
+    }
     @Override
     public void createEnrolment(Enrolment enrolment) {
         versionedCcaCommander.createEnrolment(enrolment);

--- a/src/test/java/seedu/ccacommander/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/CreateEventCommandTest.java
@@ -26,6 +26,7 @@ import seedu.ccacommander.model.VersionCaptures;
 import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.event.Event;
 import seedu.ccacommander.model.member.Member;
+import seedu.ccacommander.model.shared.Name;
 import seedu.ccacommander.testutil.EventBuilder;
 
 public class CreateEventCommandTest {
@@ -182,6 +183,16 @@ public class CreateEventCommandTest {
 
         @Override
         public void deleteEnrolment(Enrolment target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteEnrolmentsWithEventName(Name eventName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteEnrolmentsWithMemberName(Name memberName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/ccacommander/logic/commands/CreateMemberCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/CreateMemberCommandTest.java
@@ -26,6 +26,7 @@ import seedu.ccacommander.model.VersionCaptures;
 import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.event.Event;
 import seedu.ccacommander.model.member.Member;
+import seedu.ccacommander.model.shared.Name;
 import seedu.ccacommander.testutil.MemberBuilder;
 
 public class CreateMemberCommandTest {
@@ -182,6 +183,16 @@ public class CreateMemberCommandTest {
 
         @Override
         public void deleteEnrolment(Enrolment target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteEnrolmentsWithEventName(Name eventName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteEnrolmentsWithMemberName(Name memberName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/ccacommander/logic/commands/DeleteEventCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/DeleteEventCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandFai
 import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.ccacommander.logic.commands.CommandTestUtil.showEventAtIndex;
 import static seedu.ccacommander.testutil.TypicalCcaCommander.getTypicalCcaCommander;
+import static seedu.ccacommander.testutil.TypicalIndexes.INDEX_FIRST_ENROLMENT;
 import static seedu.ccacommander.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.ccacommander.testutil.TypicalIndexes.INDEX_SECOND_EVENT;
 
@@ -17,6 +18,7 @@ import seedu.ccacommander.logic.Messages;
 import seedu.ccacommander.model.Model;
 import seedu.ccacommander.model.ModelManager;
 import seedu.ccacommander.model.UserPrefs;
+import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.event.Event;
 
 /**
@@ -30,6 +32,7 @@ public class DeleteEventCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Event eventToDelete = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        Enrolment enrolmentToDelete = model.getFilteredEnrolmentList().get(INDEX_FIRST_ENROLMENT.getZeroBased());
         DeleteEventCommand deleteEventCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
 
         String commitMessage = String.format(DeleteEventCommand.MESSAGE_COMMIT, eventToDelete.getName());
@@ -38,6 +41,7 @@ public class DeleteEventCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getCcaCommander(), new UserPrefs());
         expectedModel.deleteEvent(eventToDelete);
+        expectedModel.deleteEnrolment(enrolmentToDelete);
         expectedModel.commit(commitMessage);
 
         assertCommandSuccess(deleteEventCommand, model, expectedMessage, expectedModel);
@@ -56,6 +60,7 @@ public class DeleteEventCommandTest {
         showEventAtIndex(model, INDEX_FIRST_EVENT);
 
         Event eventToDelete = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        Enrolment enrolmentToDelete = model.getFilteredEnrolmentList().get(INDEX_FIRST_ENROLMENT.getZeroBased());
         DeleteEventCommand deleteEventCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
 
         String commitMessage = String.format(DeleteEventCommand.MESSAGE_COMMIT, eventToDelete.getName());
@@ -64,6 +69,7 @@ public class DeleteEventCommandTest {
 
         Model expectedModel = new ModelManager(model.getCcaCommander(), new UserPrefs());
         expectedModel.deleteEvent(eventToDelete);
+        expectedModel.deleteEnrolment(enrolmentToDelete);
         expectedModel.commit(commitMessage);
         showNoEvent(expectedModel);
 

--- a/src/test/java/seedu/ccacommander/logic/commands/DeleteMemberCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/DeleteMemberCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandFai
 import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.ccacommander.logic.commands.CommandTestUtil.showMemberAtIndex;
 import static seedu.ccacommander.testutil.TypicalCcaCommander.getTypicalCcaCommander;
+import static seedu.ccacommander.testutil.TypicalIndexes.INDEX_FIRST_ENROLMENT;
 import static seedu.ccacommander.testutil.TypicalIndexes.INDEX_FIRST_MEMBER;
 import static seedu.ccacommander.testutil.TypicalIndexes.INDEX_SECOND_MEMBER;
 
@@ -17,6 +18,7 @@ import seedu.ccacommander.logic.Messages;
 import seedu.ccacommander.model.Model;
 import seedu.ccacommander.model.ModelManager;
 import seedu.ccacommander.model.UserPrefs;
+import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.member.Member;
 
 /**
@@ -30,6 +32,7 @@ public class DeleteMemberCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Member memberToDelete = model.getFilteredMemberList().get(INDEX_FIRST_MEMBER.getZeroBased());
+        Enrolment enrolmentToDelete = model.getFilteredEnrolmentList().get(INDEX_FIRST_ENROLMENT.getZeroBased());
         DeleteMemberCommand deleteMemberCommand = new DeleteMemberCommand(INDEX_FIRST_MEMBER);
 
         String commitMessage = String.format(DeleteMemberCommand.MESSAGE_COMMIT, memberToDelete.getName());
@@ -38,6 +41,7 @@ public class DeleteMemberCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getCcaCommander(), new UserPrefs());
         expectedModel.deleteMember(memberToDelete);
+        expectedModel.deleteEnrolment(enrolmentToDelete);
         expectedModel.commit(commitMessage);
 
         assertCommandSuccess(deleteMemberCommand, model, expectedMessage, expectedModel);
@@ -56,6 +60,7 @@ public class DeleteMemberCommandTest {
         showMemberAtIndex(model, INDEX_FIRST_MEMBER);
 
         Member memberToDelete = model.getFilteredMemberList().get(INDEX_FIRST_MEMBER.getZeroBased());
+        Enrolment enrolmentToDelete = model.getFilteredEnrolmentList().get(INDEX_FIRST_ENROLMENT.getZeroBased());
         DeleteMemberCommand deleteMemberCommand = new DeleteMemberCommand(INDEX_FIRST_MEMBER);
 
         String commitMessage = String.format(DeleteMemberCommand.MESSAGE_COMMIT, memberToDelete.getName());
@@ -63,6 +68,7 @@ public class DeleteMemberCommandTest {
                 Messages.format(memberToDelete));
 
         Model expectedModel = new ModelManager(model.getCcaCommander(), new UserPrefs());
+        expectedModel.deleteEnrolment(enrolmentToDelete);
         expectedModel.deleteMember(memberToDelete);
         expectedModel.commit(commitMessage);
         showNoMember(expectedModel);

--- a/src/test/java/seedu/ccacommander/logic/commands/EnrolCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/EnrolCommandTest.java
@@ -37,6 +37,7 @@ import seedu.ccacommander.model.event.Event;
 import seedu.ccacommander.model.event.UniqueEventList;
 import seedu.ccacommander.model.member.Member;
 import seedu.ccacommander.model.member.UniqueMemberList;
+import seedu.ccacommander.model.shared.Name;
 import seedu.ccacommander.testutil.EnrolmentBuilder;
 
 public class EnrolCommandTest {
@@ -200,6 +201,16 @@ public class EnrolCommandTest {
 
         @Override
         public void deleteEnrolment(Enrolment target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteEnrolmentsWithEventName(Name eventName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteEnrolmentsWithMemberName(Name memberName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/ccacommander/logic/commands/UnenrolCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/UnenrolCommandTest.java
@@ -83,6 +83,7 @@ public class UnenrolCommandTest {
 
         // Delete the first member first and assert if the command is successful
         Member memberToDelete = model.getFilteredMemberList().get(INDEX_FIRST_MEMBER.getZeroBased());
+        Enrolment enrolmentToDelete = model.getFilteredEnrolmentList().get(INDEX_FIRST_ENROLMENT.getZeroBased());
         DeleteMemberCommand deleteMemberCommand = new DeleteMemberCommand(INDEX_FIRST_MEMBER);
 
         String commitMessage = String.format(DeleteMemberCommand.MESSAGE_COMMIT, memberToDelete.getName());
@@ -91,6 +92,7 @@ public class UnenrolCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getCcaCommander(), new UserPrefs());
         expectedModel.deleteMember(memberToDelete);
+        expectedModel.deleteEnrolment(enrolmentToDelete);
         expectedModel.commit(commitMessage);
         assertCommandSuccess(deleteMemberCommand, model, expectedMessage, expectedModel);
 
@@ -108,6 +110,7 @@ public class UnenrolCommandTest {
 
         // Delete the first event first and assert if the command is successful
         Event eventToDelete = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        Enrolment enrolmentToDelete = model.getFilteredEnrolmentList().get(INDEX_FIRST_ENROLMENT.getZeroBased());
         DeleteEventCommand deleteEventCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
 
         String commitMessage = String.format(deleteEventCommand.MESSAGE_COMMIT, eventToDelete.getName());
@@ -116,6 +119,7 @@ public class UnenrolCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getCcaCommander(), new UserPrefs());
         expectedModel.deleteEvent(eventToDelete);
+        expectedModel.deleteEnrolment(enrolmentToDelete);
         expectedModel.commit(commitMessage);
         assertCommandSuccess(deleteEventCommand, model, expectedMessage, expectedModel);
 


### PR DESCRIPTION
Closes #138 

What have you done in this PR?
* Created new functions in model called `deleteEnrolmentsWithEventName()` and `deleteEnrolmentsWithMemberName()`
* Update tests

Dev Testing Steps / Screenshots
First, enrol members to events and deleting the member should also delete associated enrolments. Likewise, deleting the event should also delete associated enrolments.

```
enrol m/1 e/1 h/0 r/r
enrol m/1 e/2 h/0 r/r
enrol m/2 e/1 h/0 r/r
enrol m/2 e/2 h/0 r/r
enrol m/1 e/3 h/0 r/r
enrol m/3 e/1 h/0 r/r
deleteMember 1
deleteEvent 1
```
