### PR TITLE
Fix Redo/Undo command showing remarks and hours

### DIFF
--- a/src/main/java/seedu/ccacommander/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/RedoCommand.java
@@ -6,6 +6,8 @@ import static seedu.ccacommander.model.Model.PREDICATE_SHOW_ALL_MEMBERS;
 
 import seedu.ccacommander.logic.commands.exceptions.CommandException;
 import seedu.ccacommander.model.Model;
+import seedu.ccacommander.ui.EventListPanel;
+import seedu.ccacommander.ui.MemberListPanel;
 
 /**
  * Redoes the latest redoable command {@code Command}
@@ -24,6 +26,10 @@ public class RedoCommand extends Command {
         }
 
         String redoCommandMessage = model.redo();
+
+        MemberListPanel.setDisplayMemberHoursAndRemark(false);
+        EventListPanel.setDisplayEventHoursAndRemark(false);
+
         model.updateFilteredMemberList(PREDICATE_SHOW_ALL_MEMBERS);
         model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
         return new CommandResult(String.format(MESSAGE_SUCCESS_REDO, redoCommandMessage));

--- a/src/main/java/seedu/ccacommander/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/UndoCommand.java
@@ -6,6 +6,8 @@ import static seedu.ccacommander.model.Model.PREDICATE_SHOW_ALL_MEMBERS;
 
 import seedu.ccacommander.logic.commands.exceptions.CommandException;
 import seedu.ccacommander.model.Model;
+import seedu.ccacommander.ui.EventListPanel;
+import seedu.ccacommander.ui.MemberListPanel;
 
 /**
  * Undoes the latest undoable command {@code Command}
@@ -24,6 +26,10 @@ public class UndoCommand extends Command {
         }
 
         String undoCommandMessage = model.undo();
+
+        MemberListPanel.setDisplayMemberHoursAndRemark(false);
+        EventListPanel.setDisplayEventHoursAndRemark(false);
+
         model.updateFilteredMemberList(PREDICATE_SHOW_ALL_MEMBERS);
         model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
         return new CommandResult(String.format(MESSAGE_SUCCESS_UNDO, undoCommandMessage));


### PR DESCRIPTION
Resolves #227 

What have you done in this PR?
* Change the order of `setIsViewCommand(false)` in undo and redo commands before filtering by all predicate

Dev Testing Steps / Screenshots
1. edit m1-e1 enrolment to add a remark
2. viewMember 1
3. undo
4. list
Remark should not be shown afterwards
