### PR TITLE
User Guide: Fix undo command format

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -256,7 +256,7 @@ Examples:
 
 Undoes the previous command that the user has entered, which has changed the data within CCACommander.
 
-Format: `redo`
+Format: `undo`
 
 ### Undoing a command: `redo`
 


### PR DESCRIPTION
Closes #213

What have you done in this PR?
* Updated undo command format to `undo`
