### PR TITLE
User Guide: Add list of commands that can be undone

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -258,12 +258,6 @@ Undoes the previous command that the user has entered, which has changed the dat
 
 Format: `undo`
 
-### Redoing a command: `redo`
-
-Redoes a command that the user has undone previously.
-
-Format: `redo`
-
 List of commands that can be undone:
 * `clear`
 * `createMember`
@@ -275,6 +269,12 @@ List of commands that can be undone:
 * `enrol`
 * `unenrol`
 * `editEnrolment`
+
+### Redoing a command: `redo`
+
+Redoes a command that the user has undone previously.
+
+Format: `redo`
 
 ### Help: `help`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -264,6 +264,18 @@ Redoes a command that the user has undone previously.
 
 Format: `redo`
 
+List of commands that can be undone:
+* `clear`
+* `createMember`
+* `deleteMember`
+* `editMember`
+* `createEvent`
+* `deleteEvent`
+* `editEvent`
+* `enrol`
+* `unenrol`
+* `editEnrolment`
+
 ### Help: `help`
 
 Displays a pop-out window that shows a link to this User Guide.


### PR DESCRIPTION
Closes #214 

What have you done in this PR?
* Added the list of commands that can be undone

Note:
Referring to @SelwynAng's comment in PR #249 about adding a list of commands that can redone, it is not necessary anymore since only when a command is undone then it can be redone. This means that the `redo` command solely relies on the `undo` command, and no other commands.
