### PR TITLE
Fix edit enrolment

### DIFF
--- a/src/main/java/seedu/ccacommander/logic/commands/EditEnrolmentCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/EditEnrolmentCommand.java
@@ -6,10 +6,13 @@ import static seedu.ccacommander.logic.parser.CliSyntax.PREFIX_HOURS;
 import static seedu.ccacommander.logic.parser.CliSyntax.PREFIX_MEMBER;
 import static seedu.ccacommander.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.ccacommander.model.Model.PREDICATE_SHOW_ALL_ENROLMENTS;
+import static seedu.ccacommander.model.Model.PREDICATE_SHOW_ALL_EVENTS;
+import static seedu.ccacommander.model.Model.PREDICATE_SHOW_ALL_MEMBERS;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import seedu.ccacommander.commons.core.index.Index;
 import seedu.ccacommander.commons.util.CollectionUtil;
@@ -97,6 +100,24 @@ public class EditEnrolmentCommand extends Command {
 
         Enrolment enrolmentToEdit = enrolmentToEditList.get(0);
         Enrolment editedEnrolment = createEditedEnrolment(enrolmentToEdit, editEnrolmentDescriptor);
+
+        targetMember.setHours(Optional.of(editedEnrolment.getHours()));
+        targetMember.setRemark(Optional.of(editedEnrolment.getRemark()));
+
+        targetEvent.setHours(Optional.of(editedEnrolment.getHours()));
+        targetEvent.setRemark(Optional.of(editedEnrolment.getRemark()));
+
+        Predicate<Member> lastMemberPredicate = model.getLastFilteredMemberPredicate();
+        Predicate<Event> lastEventPredicate = model.getLastFilteredEventPredicate();
+
+        // Updating to lastPredicate alone cannot refresh the member/EVENT card
+        // We need to revert back to original list and then update again the last predicate
+
+        model.updateFilteredMemberList(PREDICATE_SHOW_ALL_MEMBERS);
+        model.updateFilteredMemberList(lastMemberPredicate);
+
+        model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
+        model.updateFilteredEventList(lastEventPredicate);
 
         model.setEnrolment(enrolmentToEdit, editedEnrolment);
         model.updateFilteredEnrolmentList(PREDICATE_SHOW_ALL_ENROLMENTS);

--- a/src/main/java/seedu/ccacommander/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/EditEventCommand.java
@@ -93,8 +93,8 @@ public class EditEventCommand extends Command {
         }
 
         model.setEvent(eventToEdit, editedEvent);
-        model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
         model.updateFilteredMemberList(PREDICATE_SHOW_ALL_MEMBERS);
+        model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
 
         model.commit(String.format(MESSAGE_COMMIT, editedEvent.getName()));
 

--- a/src/main/java/seedu/ccacommander/model/Model.java
+++ b/src/main/java/seedu/ccacommander/model/Model.java
@@ -164,6 +164,8 @@ public interface Model {
     ObservableList<Event> getFilteredEventList();
 
     ObservableList<Enrolment> getFilteredEnrolmentList();
+    Predicate<Member> getLastFilteredMemberPredicate();
+    Predicate<Event> getLastFilteredEventPredicate();
 
     /**
      * Updates the filter of the filtered member list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/ccacommander/model/ModelManager.java
+++ b/src/main/java/seedu/ccacommander/model/ModelManager.java
@@ -33,6 +33,8 @@ public class ModelManager implements Model {
     private final FilteredList<Event> filteredEvents;
     private final FilteredList<Enrolment> filteredEnrolments;
 
+    private Predicate<Event> lastEventPredicate;
+    private Predicate<Member> lastMemberPredicate;
     /**
      * Initializes a ModelManager with the given CcaCommander and userPrefs.
      */
@@ -46,6 +48,8 @@ public class ModelManager implements Model {
         filteredMembers = new FilteredList<>(this.versionedCcaCommander.getMemberList());
         filteredEvents = new FilteredList<>(this.versionedCcaCommander.getEventList());
         filteredEnrolments = new FilteredList<>(this.versionedCcaCommander.getEnrolmentList());
+        lastMemberPredicate = PREDICATE_SHOW_ALL_MEMBERS;
+        lastEventPredicate = PREDICATE_SHOW_ALL_EVENTS;
     }
 
     public ModelManager() {
@@ -325,15 +329,25 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public Predicate<Member> getLastFilteredMemberPredicate() {
+        return this.lastMemberPredicate;
+    }
+    @Override
+    public Predicate<Event> getLastFilteredEventPredicate() {
+        return this.lastEventPredicate;
+    }
+    @Override
     public void updateFilteredMemberList(Predicate<Member> predicate) {
         requireNonNull(predicate);
         filteredMembers.setPredicate(predicate);
+        this.lastMemberPredicate = predicate;
     }
 
     @Override
     public void updateFilteredEventList(Predicate<Event> predicate) {
         requireNonNull(predicate);
         filteredEvents.setPredicate(predicate);
+        this.lastEventPredicate = predicate;
     }
 
     @Override

--- a/src/test/java/seedu/ccacommander/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/CreateEventCommandTest.java
@@ -238,8 +238,17 @@ public class CreateEventCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+
         @Override
         public void updateFilteredEnrolmentList(Predicate<Enrolment> enrolment) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public Predicate<Member> getLastFilteredMemberPredicate() {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public Predicate<Event> getLastFilteredEventPredicate() {
             throw new AssertionError("This method should not be called.");
         }
         @Override

--- a/src/test/java/seedu/ccacommander/logic/commands/CreateMemberCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/CreateMemberCommandTest.java
@@ -215,6 +215,7 @@ public class CreateMemberCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+
         @Override
         public void updateFilteredMemberList(Predicate<Member> predicate) {
             throw new AssertionError("This method should not be called.");
@@ -237,6 +238,14 @@ public class CreateMemberCommandTest {
 
         @Override
         public void updateFilteredEnrolmentList(Predicate<Enrolment> enrolment) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public Predicate<Member> getLastFilteredMemberPredicate() {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public Predicate<Event> getLastFilteredEventPredicate() {
             throw new AssertionError("This method should not be called.");
         }
         @Override

--- a/src/test/java/seedu/ccacommander/logic/commands/CreateMemberCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/CreateMemberCommandTest.java
@@ -215,7 +215,6 @@ public class CreateMemberCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-
         @Override
         public void updateFilteredMemberList(Predicate<Member> predicate) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/ccacommander/logic/commands/EnrolCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/EnrolCommandTest.java
@@ -264,6 +264,14 @@ public class EnrolCommandTest {
         public void updateFilteredEnrolmentList(Predicate<Enrolment> enrolment) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public Predicate<Member> getLastFilteredMemberPredicate() {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public Predicate<Event> getLastFilteredEventPredicate() {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public Collection<Name> updateMemberHoursAndRemark(Name eventName) {

--- a/src/test/java/seedu/ccacommander/model/ModelManagerTest.java
+++ b/src/test/java/seedu/ccacommander/model/ModelManagerTest.java
@@ -19,15 +19,18 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.ccacommander.commons.core.GuiSettings;
 import seedu.ccacommander.model.enrolment.Enrolment;
 import seedu.ccacommander.model.enrolment.exceptions.EnrolmentNotFoundException;
+import seedu.ccacommander.model.event.Event;
 import seedu.ccacommander.model.event.EventNameContainsKeywordsPredicate;
 import seedu.ccacommander.model.exceptions.RedoStateException;
 import seedu.ccacommander.model.exceptions.UndoStateException;
+import seedu.ccacommander.model.member.Member;
 import seedu.ccacommander.model.member.MemberNameContainsKeywordsPredicate;
 import seedu.ccacommander.testutil.CcaCommanderBuilder;
 import seedu.ccacommander.testutil.EnrolmentBuilder;
@@ -183,6 +186,18 @@ public class ModelManagerTest {
     @Test
     public void getFilteredEnrolmentList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredEnrolmentList().remove(0));
+    }
+
+    @Test
+    public void getLastFilteredMemberPredicate_noOperation_returnsDefaultList() {
+        Predicate<Member> lastMemberPredicate = modelManager.getLastFilteredMemberPredicate();
+        assertEquals(lastMemberPredicate, PREDICATE_SHOW_ALL_MEMBERS);
+    }
+
+    @Test
+    public void getLastFilteredEventPredicate_noOperation_returnsDefaultList() {
+        Predicate<Event> lastEventPredicate = modelManager.getLastFilteredEventPredicate();
+        assertEquals(lastEventPredicate, PREDICATE_SHOW_ALL_EVENTS);
     }
 
     @Test

--- a/src/test/java/seedu/ccacommander/model/ModelManagerTest.java
+++ b/src/test/java/seedu/ccacommander/model/ModelManagerTest.java
@@ -189,9 +189,26 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getLastFilteredMemberPredicate_memberOperation_returnsMemberPredicate() {
+        String[] memberKeywords = ALICE.getName().name.split("\\s+");
+        Predicate<Member> pred = new MemberNameContainsKeywordsPredicate(Arrays.asList(memberKeywords));
+        modelManager.updateFilteredMemberList(pred);
+        Predicate<Member> lastMemberPredicate = modelManager.getLastFilteredMemberPredicate();
+        assertEquals(lastMemberPredicate, pred);
+    }
+
+    @Test
     public void getLastFilteredMemberPredicate_noOperation_returnsDefaultList() {
         Predicate<Member> lastMemberPredicate = modelManager.getLastFilteredMemberPredicate();
         assertEquals(lastMemberPredicate, PREDICATE_SHOW_ALL_MEMBERS);
+    }
+    @Test
+    public void getLastFilteredEventPredicate_eventOperation_returnsEventPredicate() {
+        String[] eventKeywords = AURORA_BOREALIS.getName().name.split("\\s+");
+        Predicate<Event> pred = new EventNameContainsKeywordsPredicate(Arrays.asList(eventKeywords));
+        modelManager.updateFilteredEventList(pred);
+        Predicate<Event> lastEventPredicate = modelManager.getLastFilteredEventPredicate();
+        assertEquals(lastEventPredicate, pred);
     }
 
     @Test


### PR DESCRIPTION
Closes #205 

What have you done in this PR?
* Fix edit enrolment to allow edited enrolment data to be displayed automatically in UI by tracking the previous predicate used by updateFilteredEventList and updateFilteredMemberList.
* Add testcases for the new methods

Dev Testing Steps / Screenshots
![image](https://github.com/AY2324S1-CS2103T-F11-1/tp/assets/99804772/3df5c420-a8e4-49e6-ae90-ccca126afb60)
