### PR TITLE
Improve test cases (deleteMember, deleteEvent, findMember, findEvent, Unenrol, Undo, Redo)

### DIFF
--- a/src/main/java/seedu/ccacommander/logic/parser/exceptions/HandledParseException.java
+++ b/src/main/java/seedu/ccacommander/logic/parser/exceptions/HandledParseException.java
@@ -18,15 +18,6 @@ public class HandledParseException extends ParseException {
     /**
      * Creates a new HandledParseException.
      * @param message
-     */
-    public HandledParseException(String message) {
-        super(message);
-        this.hpeMessage = message;
-    }
-
-    /**
-     * Creates a new HandledParseException.
-     * @param message
      * @param cause
      */
     public HandledParseException(String message, Throwable cause) {

--- a/src/test/java/seedu/ccacommander/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/CommandTestUtil.java
@@ -263,4 +263,14 @@ public class CommandTestUtil {
         model.deleteEvent(firstEvent);
         model.commit(String.format(MESSAGE_COMMIT, firstEvent.getName()));
     }
+
+    /**
+     * Deletes the last event in {@code model}'s filtered event list from {@code model}'s CCACommander.
+     */
+    public static void deleteLastEvent(Model model) {
+        int sizeofEventList = model.getFilteredEventList().size();
+        Event lastEvent = model.getFilteredEventList().get(sizeofEventList - 1);
+        model.deleteEvent(lastEvent);
+        model.commit(String.format(MESSAGE_COMMIT, lastEvent.getName()));
+    }
 }

--- a/src/test/java/seedu/ccacommander/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/CommandTestUtil.java
@@ -2,6 +2,7 @@ package seedu.ccacommander.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.ccacommander.logic.commands.DeleteEventCommand.MESSAGE_COMMIT;
 import static seedu.ccacommander.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.ccacommander.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.ccacommander.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -252,5 +253,14 @@ public class CommandTestUtil {
         model.updateFilteredEnrolmentList(new EnrolmentExistsPredicate(enrolment));
 
         assertEquals(1, model.getFilteredEnrolmentList().size());
+    }
+
+    /**
+     * Deletes the first event in {@code model}'s filtered event list from {@code model}'s CCACommander.
+     */
+    public static void deleteFirstEvent(Model model) {
+        Event firstEvent = model.getFilteredEventList().get(0);
+        model.deleteEvent(firstEvent);
+        model.commit(String.format(MESSAGE_COMMIT, firstEvent.getName()));
     }
 }

--- a/src/test/java/seedu/ccacommander/logic/commands/FindEventCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/FindEventCommandTest.java
@@ -65,6 +65,26 @@ public class FindEventCommandTest {
     }
 
     @Test
+    public void execute_oneKeyword_oneEventFound() {
+        String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 1);
+        EventNameContainsKeywordsPredicate predicate = preparePredicate("Aurora");
+        FindEventCommand command = new FindEventCommand(predicate);
+        expectedModel.updateFilteredEventList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(AURORA_BOREALIS), model.getFilteredEventList());
+    }
+
+    @Test
+    public void execute_notFirstNameKeyword_oneEventFound() {
+        String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 1);
+        EventNameContainsKeywordsPredicate predicate = preparePredicate("Borealis");
+        FindEventCommand command = new FindEventCommand(predicate);
+        expectedModel.updateFilteredEventList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(AURORA_BOREALIS), model.getFilteredEventList());
+    }
+
+    @Test
     public void execute_multipleKeywords_multipleEventsFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 3);
         EventNameContainsKeywordsPredicate predicate = preparePredicate("Aurora Boxing Chinese");
@@ -72,6 +92,16 @@ public class FindEventCommandTest {
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(AURORA_BOREALIS, BOXING_DAY, CHINESE_NEW_YEAR), model.getFilteredEventList());
+    }
+
+    @Test
+    public void execute_oneKeywordWithDifferentCapitalisation_oneEventFound() {
+        String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 1);
+        EventNameContainsKeywordsPredicate predicate = preparePredicate("aUrORA");
+        FindEventCommand command = new FindEventCommand(predicate);
+        expectedModel.updateFilteredEventList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(AURORA_BOREALIS), model.getFilteredEventList());
     }
 
     @Test

--- a/src/test/java/seedu/ccacommander/logic/commands/FindMemberCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/FindMemberCommandTest.java
@@ -65,6 +65,26 @@ public class FindMemberCommandTest {
     }
 
     @Test
+    public void execute_oneKeyword_oneMemberFound() {
+        String expectedMessage = String.format(MESSAGE_MEMBERS_LISTED_OVERVIEW, 1);
+        MemberNameContainsKeywordsPredicate predicate = preparePredicate("Carl");
+        FindMemberCommand command = new FindMemberCommand(predicate);
+        expectedModel.updateFilteredMemberList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getFilteredMemberList());
+    }
+
+    @Test
+    public void execute_notFirstNameKeyword_oneMemberFound() {
+        String expectedMessage = String.format(MESSAGE_MEMBERS_LISTED_OVERVIEW, 1);
+        MemberNameContainsKeywordsPredicate predicate = preparePredicate("Kurz");
+        FindMemberCommand command = new FindMemberCommand(predicate);
+        expectedModel.updateFilteredMemberList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getFilteredMemberList());
+    }
+
+    @Test
     public void execute_multipleKeywords_multipleMembersFound() {
         String expectedMessage = String.format(MESSAGE_MEMBERS_LISTED_OVERVIEW, 3);
         MemberNameContainsKeywordsPredicate predicate = preparePredicate("Carl Elle Fiona");
@@ -72,6 +92,16 @@ public class FindMemberCommandTest {
         expectedModel.updateFilteredMemberList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredMemberList());
+    }
+
+    @Test
+    public void execute_oneKeywordWithDifferentCapitalisation_oneMemberFound() {
+        String expectedMessage = String.format(MESSAGE_MEMBERS_LISTED_OVERVIEW, 1);
+        MemberNameContainsKeywordsPredicate predicate = preparePredicate("cArL");
+        FindMemberCommand command = new FindMemberCommand(predicate);
+        expectedModel.updateFilteredMemberList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getFilteredMemberList());
     }
 
     @Test

--- a/src/test/java/seedu/ccacommander/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/RedoCommandTest.java
@@ -2,6 +2,8 @@ package seedu.ccacommander.logic.commands;
 
 import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.ccacommander.logic.commands.CommandTestUtil.deleteFirstEvent;
+import static seedu.ccacommander.logic.commands.CommandTestUtil.deleteLastEvent;
 import static seedu.ccacommander.testutil.TypicalCcaCommander.getTypicalCcaCommander;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -12,7 +14,6 @@ import seedu.ccacommander.model.ModelManager;
 import seedu.ccacommander.model.UserPrefs;
 
 public class RedoCommandTest {
-    public static final String COMMIT_MESSAGE = "Commit Message";
     private Model model;
     private Model expectedModel;
 
@@ -20,22 +21,40 @@ public class RedoCommandTest {
     public void setUp() {
         model = new ModelManager(getTypicalCcaCommander(), new UserPrefs());
         expectedModel = new ModelManager(getTypicalCcaCommander(), new UserPrefs());
+
+        deleteFirstEvent(model);
+        deleteLastEvent(model);
+        deleteFirstEvent(model);
+        for (int i = 0; i < 3; i++) {
+            model.undo();
+        }
+
+        deleteFirstEvent(expectedModel);
+        deleteLastEvent(expectedModel);
+        deleteFirstEvent(expectedModel);
+        for (int i = 0; i < 3; i++) {
+            expectedModel.undo();
+        }
     }
 
     @Test
-    public void execute_hasNextState_throwsCommandException() {
-        model.commit(COMMIT_MESSAGE);
-        model.undo();
+    public void execute_multiple_redos() {
+        // multiple redoable commands in model
+        String redoMessageFirst = expectedModel.redo();
+        assertCommandSuccess(new RedoCommand(), model,
+                String.format(RedoCommand.MESSAGE_SUCCESS_REDO, redoMessageFirst), expectedModel);
 
-        String expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS_REDO, COMMIT_MESSAGE);
-        expectedModel.commit(COMMIT_MESSAGE);
+        // two redoable commands in model
+        String redoMessageSecond = expectedModel.redo();
+        assertCommandSuccess(new RedoCommand(), model,
+                String.format(RedoCommand.MESSAGE_SUCCESS_REDO, redoMessageSecond), expectedModel);
 
-        assertCommandSuccess(new RedoCommand(), model, expectedMessage, expectedModel);
-    }
+        // one redoable command in model
+        String redoMessageThird = expectedModel.redo();
+        assertCommandSuccess(new RedoCommand(), model,
+                String.format(RedoCommand.MESSAGE_SUCCESS_REDO, redoMessageThird), expectedModel);
 
-    @Test
-    public void execute_noNextState_throwsCommandException() {
-        model.commit(COMMIT_MESSAGE);
+        // no more redoable command in model
         assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_NO_AVAILABLE_COMMAND);
     }
 }

--- a/src/test/java/seedu/ccacommander/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/UndoCommandTest.java
@@ -2,6 +2,7 @@ package seedu.ccacommander.logic.commands;
 
 import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.ccacommander.logic.commands.CommandTestUtil.deleteFirstEvent;
 import static seedu.ccacommander.testutil.TypicalCcaCommander.getTypicalCcaCommander;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -12,7 +13,6 @@ import seedu.ccacommander.model.ModelManager;
 import seedu.ccacommander.model.UserPrefs;
 
 public class UndoCommandTest {
-    public static final String COMMIT_MESSAGE = "Commit Message";
     private Model model;
     private Model expectedModel;
 
@@ -20,21 +20,26 @@ public class UndoCommandTest {
     public void setUp() {
         model = new ModelManager(getTypicalCcaCommander(), new UserPrefs());
         expectedModel = new ModelManager(getTypicalCcaCommander(), new UserPrefs());
+
+        deleteFirstEvent(model);
+        deleteFirstEvent(model);
+        deleteFirstEvent(expectedModel);
+        deleteFirstEvent(expectedModel);
     }
 
     @Test
-    public void execute_hasPreviousState_success() {
-        model.commit(COMMIT_MESSAGE);
+    public void execute_multiple_undos() {
+        // multiple undoable commands in model
+        String undoMessageFirst = expectedModel.undo();
+        assertCommandSuccess(new UndoCommand(), model,
+                String.format(UndoCommand.MESSAGE_SUCCESS_UNDO, undoMessageFirst), expectedModel);
 
-        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS_UNDO, COMMIT_MESSAGE);
-        expectedModel.commit(COMMIT_MESSAGE);
-        expectedModel.undo();
+        // one undoable command in model
+        String undoMessageSecond = expectedModel.undo();
+        assertCommandSuccess(new UndoCommand(), model,
+                String.format(UndoCommand.MESSAGE_SUCCESS_UNDO, undoMessageSecond), expectedModel);
 
-        assertCommandSuccess(new UndoCommand(), model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_noPreviousState_throwsCommandException() {
+        // no more undoable command in model
         assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_NO_AVAILABLE_COMMAND);
     }
 }

--- a/src/test/java/seedu/ccacommander/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/ccacommander/logic/commands/UndoCommandTest.java
@@ -3,6 +3,7 @@ package seedu.ccacommander.logic.commands;
 import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.ccacommander.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.ccacommander.logic.commands.CommandTestUtil.deleteFirstEvent;
+import static seedu.ccacommander.logic.commands.CommandTestUtil.deleteLastEvent;
 import static seedu.ccacommander.testutil.TypicalCcaCommander.getTypicalCcaCommander;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -22,8 +23,10 @@ public class UndoCommandTest {
         expectedModel = new ModelManager(getTypicalCcaCommander(), new UserPrefs());
 
         deleteFirstEvent(model);
+        deleteLastEvent(model);
         deleteFirstEvent(model);
         deleteFirstEvent(expectedModel);
+        deleteLastEvent(expectedModel);
         deleteFirstEvent(expectedModel);
     }
 
@@ -34,10 +37,15 @@ public class UndoCommandTest {
         assertCommandSuccess(new UndoCommand(), model,
                 String.format(UndoCommand.MESSAGE_SUCCESS_UNDO, undoMessageFirst), expectedModel);
 
-        // one undoable command in model
+        // two undoable commands in model
         String undoMessageSecond = expectedModel.undo();
         assertCommandSuccess(new UndoCommand(), model,
                 String.format(UndoCommand.MESSAGE_SUCCESS_UNDO, undoMessageSecond), expectedModel);
+
+        // one undoable command in model
+        String undoMessageThird = expectedModel.undo();
+        assertCommandSuccess(new UndoCommand(), model,
+                String.format(UndoCommand.MESSAGE_SUCCESS_UNDO, undoMessageThird), expectedModel);
 
         // no more undoable command in model
         assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_NO_AVAILABLE_COMMAND);

--- a/src/test/java/seedu/ccacommander/logic/parser/DeleteEventCommandParserTest.java
+++ b/src/test/java/seedu/ccacommander/logic/parser/DeleteEventCommandParserTest.java
@@ -18,8 +18,38 @@ public class DeleteEventCommandParserTest {
     }
 
     @Test
+    public void parse_emptyInput_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteEventCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_whitespaceInput_throwsParseException() {
+        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteEventCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteEventCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_zeroInput_throwsParseException() {
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteEventCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeInput_throwsParseException() {
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteEventCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleValidInputs_throwsParseException() {
+        assertParseFailure(parser, "1 2 3", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeleteEventCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/ccacommander/logic/parser/DeleteMemberCommandParserTest.java
+++ b/src/test/java/seedu/ccacommander/logic/parser/DeleteMemberCommandParserTest.java
@@ -18,8 +18,39 @@ public class DeleteMemberCommandParserTest {
     }
 
     @Test
+    public void parse_emptyInput_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteMemberCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_whitespaceInput_throwsParseException() {
+        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteMemberCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeleteMemberCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_zeroInput_throwsParseException() {
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteMemberCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeInput_throwsParseException() {
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteMemberCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleValidInputs_throwsParseException() {
+        assertParseFailure(parser, "1 2 3", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteMemberCommand.MESSAGE_USAGE));
+    }
+
 }

--- a/src/test/java/seedu/ccacommander/logic/parser/UnenrolCommandParserTest.java
+++ b/src/test/java/seedu/ccacommander/logic/parser/UnenrolCommandParserTest.java
@@ -32,7 +32,7 @@ public class UnenrolCommandParserTest {
         UnenrolCommand expectedUnenrolEventCommand =
                 new UnenrolCommand(VALID_INDEX_ONE, VALID_INDEX_TWO);
 
-        // No preamble
+        // Member index followed by event index
         assertParseSuccess(parser, MEMBER_INDEX_DESC_ONE + EVENT_INDEX_DESC_TWO,
                 expectedUnenrolEventCommand);
 

--- a/src/test/java/seedu/ccacommander/logic/parser/UnenrolCommandParserTest.java
+++ b/src/test/java/seedu/ccacommander/logic/parser/UnenrolCommandParserTest.java
@@ -32,6 +32,14 @@ public class UnenrolCommandParserTest {
         UnenrolCommand expectedUnenrolEventCommand =
                 new UnenrolCommand(VALID_INDEX_ONE, VALID_INDEX_TWO);
 
+        // No preamble
+        assertParseSuccess(parser, MEMBER_INDEX_DESC_ONE + EVENT_INDEX_DESC_TWO,
+                expectedUnenrolEventCommand);
+
+        // Event index followed by Member Index
+        assertParseSuccess(parser, EVENT_INDEX_DESC_TWO + MEMBER_INDEX_DESC_ONE,
+                expectedUnenrolEventCommand);
+
         // whitespace only preamble
         assertParseSuccess(parser,
                 PREAMBLE_WHITESPACE + MEMBER_INDEX_DESC_ONE
@@ -41,7 +49,6 @@ public class UnenrolCommandParserTest {
     @Test
     public void parse_repeatedValue_failure() {
         String validExpectedEnrolmentString = MEMBER_INDEX_DESC_ONE + EVENT_INDEX_DESC_TWO;
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnenrolCommand.MESSAGE_USAGE);
 
         // multiple member indexes
         assertParseFailure(parser, MEMBER_INDEX_DESC_ONE + validExpectedEnrolmentString,
@@ -56,26 +63,6 @@ public class UnenrolCommandParserTest {
                 validExpectedEnrolmentString + MEMBER_INDEX_DESC_ONE
                         + EVENT_INDEX_DESC_TWO + validExpectedEnrolmentString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MEMBER, PREFIX_EVENT));
-
-        // invalid value followed by valid value
-
-        // invalid member index
-        assertParseFailure(parser, INVALID_MEMBER_INDEX_DESC + EVENT_INDEX_DESC_TWO,
-                expectedMessage);
-
-        // invalid event index
-        assertParseFailure(parser, INVALID_EVENT_INDEX_DESC + MEMBER_INDEX_DESC_ONE,
-                expectedMessage);
-
-        // valid value followed by invalid value
-
-        // invalid member index
-        assertParseFailure(parser, EVENT_INDEX_DESC_TWO + INVALID_MEMBER_INDEX_DESC,
-                expectedMessage);
-
-        // invalid event index
-        assertParseFailure(parser, MEMBER_INDEX_DESC_ONE + INVALID_EVENT_INDEX_DESC,
-                expectedMessage);
     }
 
     @Test
@@ -119,25 +106,33 @@ public class UnenrolCommandParserTest {
             HandledParseException hpe = (HandledParseException) pe;
             assertEquals(expectedMessage, hpe.getMessage());
         }
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + MEMBER_INDEX_DESC_ONE
+                + EVENT_INDEX_DESC_TWO, expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnenrolCommand.MESSAGE_USAGE);
-        // invalid member index
+        // invalid member index followed by valid event index
         assertParseFailure(parser, INVALID_MEMBER_INDEX_DESC + EVENT_INDEX_DESC_TWO,
                 expectedMessage);
 
-        // invalid event index
+        // invalid event index followed by valid member index
+        assertParseFailure(parser, INVALID_EVENT_INDEX_DESC + MEMBER_INDEX_DESC_ONE,
+                expectedMessage);
+
+        // valid event index followed by invalid member index
+        assertParseFailure(parser, EVENT_INDEX_DESC_TWO + INVALID_MEMBER_INDEX_DESC,
+                expectedMessage);
+
+        // valid member index followed by invalid event index
         assertParseFailure(parser, MEMBER_INDEX_DESC_ONE + INVALID_EVENT_INDEX_DESC,
                 expectedMessage);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_MEMBER_INDEX_DESC + INVALID_EVENT_INDEX_DESC,
                 expectedMessage);
-
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + MEMBER_INDEX_DESC_ONE
-                        + EVENT_INDEX_DESC_TWO, expectedMessage);
     }
 }


### PR DESCRIPTION
This PR adds more test cases for various commands and parsers.

Added more test cases for `deleteMemberCommandParser` and `deleteEventCommandParser` to take into account more examples of erroneous inputs such as:
- Empty input
- Whitespace input
- Zero input
- Negative input
- Multiple index input


Added more test cases for `findMemberCommand` and `findEventCommand` to take into account more varied types of user inputs:
- User inputs one keyword for one member/event
- User inputs a keyword which is not the first word of the name for one member/event
- User inputs a keyword with varied capitalization

Cleaned up test cases for `UnenrolCommandParser`
- Remove duplicate test cases
- Add new test case testing for command parser success when member index and event index are switched around

Removed old test cases for `UndoCommand` and `RedoCommand` and added new test cases which reflect what the users will do in real life when he/she enters commands that change the data within CCACommander. The `deleteEvent` command is used to test the changing of states.