### PR TITLE
FindCommands: Hide hours and remarks on execute

### DIFF
--- a/src/main/java/seedu/ccacommander/logic/commands/FindEventCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/FindEventCommand.java
@@ -31,10 +31,10 @@ public class FindEventCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredEventList(predicate);
-
         MemberListPanel.setDisplayMemberHoursAndRemark(false);
         EventListPanel.setDisplayEventHoursAndRemark(false);
+
+        model.updateFilteredEventList(predicate);
 
         return new CommandResult(
                 String.format(Messages.MESSAGE_EVENTS_LISTED_OVERVIEW, model.getFilteredEventList().size()));

--- a/src/main/java/seedu/ccacommander/logic/commands/FindMemberCommand.java
+++ b/src/main/java/seedu/ccacommander/logic/commands/FindMemberCommand.java
@@ -31,10 +31,11 @@ public class FindMemberCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredMemberList(predicate);
-
         MemberListPanel.setDisplayMemberHoursAndRemark(false);
         EventListPanel.setDisplayEventHoursAndRemark(false);
+
+        model.updateFilteredMemberList(predicate);
+
         return new CommandResult(
                 String.format(Messages.MESSAGE_MEMBERS_LISTED_OVERVIEW, model.getFilteredMemberList().size()));
     }

--- a/src/main/java/seedu/ccacommander/model/CommandHistory.java
+++ b/src/main/java/seedu/ccacommander/model/CommandHistory.java
@@ -109,7 +109,6 @@ public class CommandHistory {
      * This will be used to move the pointer past the last command.
      */
     public void resetPointer() {
-        logger.info("----------------[COMMAND HISTORY RESET POINTER]");
         this.currentCommandPointer = this.commandHistoryList.size();
     }
 


### PR DESCRIPTION
Closes #282 

What have you done in this PR?
* Hide hours and remarks after find commands
* Remove CommandHistory Reset Pointer Logging

Dev Testing Steps / Screenshots
`viewMember` a member with events
`findEvent` another event not related
Remarks and hours should not be shown

<img width="718" alt="image" src="https://github.com/AY2324S1-CS2103T-F11-1/tp/assets/56021409/f1d572b0-96b9-4238-9fd9-8aa20a3a1716">
<img width="722" alt="image" src="https://github.com/AY2324S1-CS2103T-F11-1/tp/assets/56021409/4e70c5aa-7be5-429d-a252-0acdc5a6d859">
